### PR TITLE
add ruby-dev and build-essential dependencies

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 class remotesyslog::install {
   include ruby
 
-  ensure_packages['libssl-dev']
+  ensure_packages['libssl-dev', 'ruby-dev', 'build-essential']
 
   package { 'remote_syslog':
     ensure   => present,
@@ -11,6 +11,8 @@ class remotesyslog::install {
     require  => [
       Class['ruby'],
       Package['libssl-dev'],
+      Package['ruby-dev'],
+      Package['build-essential'],
     ],
   }
 

--- a/spec/classes/remotesyslog_spec.rb
+++ b/spec/classes/remotesyslog_spec.rb
@@ -17,6 +17,8 @@ describe 'remotesyslog' do
 
       it { should contain_class('ruby') }
       it { should contain_package('libssl-dev') }
+      it { should contain_package('ruby-dev') }
+      it { should contain_package('build-essential') }
 
       it { should contain_file('/etc/init/remote_syslog.conf') }
       it { should contain_file('/etc/init.d/remote_syslog').with_ensure('link') }


### PR DESCRIPTION
While installing on an Ubuntu 13.10 install, I found these packages to be needed to use remotesyslog.
